### PR TITLE
Update init.lua

### DIFF
--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1416,7 +1416,11 @@ function GameStore.processOutfitPurchase(player, offerSexIdTable, addon)
 end
 
 function GameStore.processMountPurchase(player, offerId)
-	player:addMount(offerId)
+if player:hasMount(offerId) then
+		return error({code = 0, message = "You already own this mount."})
+	else
+		player:addMount(offerId)
+	end
 end
 
 function GameStore.processNameChangePurchase(player, offerId, productType, newName, offerName, offerPrice)


### PR DESCRIPTION
Fix multiple purchase of the same mount


# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Behaviour
### **Actual**

By buying a mount you could buy it indefinitely. Losing coins.

### **Expected**

When buying the same mount more than 1 time, it should indicate that you already have it.

## Fixes

  - [x] if player:hasMount()  was added to correctly respond to the purchase request and respond if the character already has it.

## Type of change

Please delete options that are not relevant.
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

I realized that this was happening while testing the server with a friend. We lost coins buying the same mount multiple times, so we decided it should be fixed.

**Test Configuration**:

  - Server Version:  Latest
  - Client: 12.85+
  - Operating System:  Windows

## Checklist

  - [x] My code follows the style guidelines of this project

  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
